### PR TITLE
add try catch block for test results

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,14 +2,18 @@ import { addDecorator } from "@storybook/react"; // <- or your view layer
 import { withTests } from "@storybook/addon-jest";
 import { addReadme } from "storybook-readme";
 import { withPerformance } from 'storybook-addon-performance';
-
-import results from "../.jest-test-results.json";
-
-addDecorator(
-  withTests({
-    results,
-  })
-);
+try {
+  if (require.resolve('../.jest-test-results.json')) {
+    const results = require('../.jest-test-results.json');
+    addDecorator(
+      withTests({
+        results,
+      })
+    );
+  }
+} catch (e) {
+  console.log('error', e);
+}
 addDecorator(addReadme);
 addDecorator(withPerformance);
 


### PR DESCRIPTION
Without the try catch block, storybook doesn't start up unless the .jest-test-results.json file exists.