### PR TITLE
add federated server port to fed story generator

### DIFF
--- a/src/components/templates/NewComponentTemplate/stories/NewComponentTemplateFed.stories.tsx
+++ b/src/components/templates/NewComponentTemplate/stories/NewComponentTemplateFed.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import DynamicRemoteContainer from "../../../../util/hooks/DynamicRemoteContainer";
 const Readme = require("../README.md").default;
-const { federatedServerPort } = require("../../../../../rs.config");
+import { federatedServerPort } from "../../../../../rs.config";
 
 export default {
   title: "Templates & Guides/NewComponentTemplate/Federated",

--- a/src/util/cli/generateComponent/index.ts
+++ b/src/util/cli/generateComponent/index.ts
@@ -135,10 +135,12 @@ const makeDefaultStoryFile = name => {
 }
 
 const makeFederatedStoryFile = name => {
+  const federatedServerPortString = "${federatedServerPort}";
   const storyFile = `import React from "react";
   import { ComponentStory, ComponentMeta } from "@storybook/react";
   import DynamicRemoteContainer from "../../../util/hooks/DynamicRemoteContainer";
   const Readme = require("../README.md").default;
+  // import { federatedServerPort } from "../../../../rs.config";
   
   export default {
     title: "Newly Generated/${name}/Federated",
@@ -183,7 +185,7 @@ const makeFederatedStoryFile = name => {
   //   componentProps: {
   //     text: "Hello World",
   //   },
-  //   url: "http://localhost:3001/remoteEntry.js",
+  //   url: \`http://localhost:${federatedServerPortString}/remoteEntry.js\`,
   //   scope: "RocketScience",
   //   module: "./${name}",
   // };
@@ -198,7 +200,7 @@ const makeFederatedStoryFile = name => {
   //   componentProps: {
   //     text: "",
   //   },
-  //   url: "http://localhost:3001/remoteEntry.js",
+  //   url: \`http://localhost:${federatedServerPortString}/remoteEntry.js\`,
   //   scope: "RocketScience",
   //   module: "./${name}",
   // };


### PR DESCRIPTION
Component generator will generate a component that makes use of the federatedServerPort from the rs.config.js file.

## Changes

- Small change to import syntax from NewComponentTemplate
- Generator will generator the template literal for the url field for dynamic remote container in the Fed story.

## API Updates

### New Features _(required)_

See above ^

### Deprecations _(required)_

N/A

### Enhancements _(optional)_

See above ^

## Checklist

- [ ] Unit tests
- [ ] Documentation

## References

N/A

Fixes #53
